### PR TITLE
fix: route raw element selectors through addBase() to fix Tailwind v3 build errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,29 @@ const aegovComponents = require("../dist/components");
 const aegovBlocks = require("../dist/blocks");
 const aegovUtil = require("../dist/utilities");
 
+/**
+ * Separates a styles object into base-level (raw element/attribute selectors)
+ * and component-level (class-based selectors).
+ *
+ * Raw element selectors (e.g. input[type="text"], textarea, select) must be
+ * registered via addBase() rather than addComponents() to comply with
+ * Tailwind CSS v3+ selector validation rules.
+ */
+function separateBaseFromComponents(styles) {
+	const base = {};
+	const components = {};
+
+	for (const [selector, value] of Object.entries(styles)) {
+		// Class selectors and @-rules belong in the component layer
+		if (selector.startsWith('.') || selector.startsWith('@')) {
+			components[selector] = value;
+		} else {
+			base[selector] = value;
+		}
+	}
+
+	return { base, components };
+}
 
 const mainFunction = ({ addBase, addComponents, addUtilities, config, postcss }) => {
 	let aegovIncludedItems = [];
@@ -23,12 +46,18 @@ const mainFunction = ({ addBase, addComponents, addUtilities, config, postcss })
 	addBase(aegovBase);
 	aegovIncludedItems.push("aegov-Base");
 
-	// Include the components style
-	addComponents(aegovComponents);
+	// Separate raw element selectors from class-based component selectors.
+	// Raw selectors (input[type="text"], textarea, etc.) must use addBase()
+	// to avoid Tailwind's strict utility/component selector validation.
+	const { base: componentBaseStyles, components: componentStyles } = separateBaseFromComponents(aegovComponents);
+	addBase(componentBaseStyles);
+	addComponents(componentStyles);
 	aegovIncludedItems.push("aegov-Components");
 
 	// Include the blocks style
-	addComponents(aegovBlocks);
+	const { base: blockBaseStyles, components: blockStyles } = separateBaseFromComponents(aegovBlocks);
+	addBase(blockBaseStyles);
+	addComponents(blockStyles);
 	aegovIncludedItems.push("aegov-Blocks");
 
 	// Include the utilities


### PR DESCRIPTION
## Summary
- Fixes #123
- Raw CSS selectors (`input[type="text"]`, `textarea`, `select`, etc.) in the compiled component/block styles were being registered via `addComponents()`, which violates Tailwind CSS v3+ strict selector validation rules
- Added a `separateBaseFromComponents()` function in `src/index.js` that automatically separates raw element/attribute selectors from class-based selectors at plugin load time
- Raw selectors are now routed to `addBase()` (where they belong per Tailwind conventions), while class-based selectors remain in `addComponents()`

## Root Cause
The compiled `dist/components.js` contains 27 selectors that don't start with `.` or `@` (e.g., `input[type="text"]`, `nav.aegov-breadcrumb`, `[data-tooltip-style]`). Similarly, `dist/blocks.js` has 4 such selectors. When passed to `addComponents()`, stricter Tailwind v3 environments (especially with Vite) reject these as invalid component/utility selectors.

## Changes
- **`src/index.js`**: Added `separateBaseFromComponents()` helper that splits style objects by selector type. Applied to both `aegovComponents` and `aegovBlocks` before registration.

## Test plan
- [x] `npm run build` completes successfully
- [x] Verified all 27 raw component selectors and 4 raw block selectors are correctly moved to `addBase()`
- [x] Verified all 530 class-based component selectors and 83 class-based block selectors remain in `addComponents()`
- [ ] Test with Vite + Tailwind v3 vanilla JS setup (as described in issue)
- [ ] Test with Angular + Vite + Tailwind v3 setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)